### PR TITLE
:sparkles: Add Flarum to framework list

### DIFF
--- a/phpmon/Domain/Integrations/Composer/PhpFrameworks.swift
+++ b/phpmon/Domain/Integrations/Composer/PhpFrameworks.swift
@@ -29,6 +29,7 @@ struct PhpFrameworks {
         
         "craftcms/craft": "Craft",
         "drupal/core": "Drupal",
+        "flarum/flarum": "Flarum",
         "tightenco/jigsaw": "Jigsaw",
         "joomla/uri": "Joomla",
         "themsaid/katana": "Katana",

--- a/phpmon/Domain/Integrations/Composer/PhpFrameworks.swift
+++ b/phpmon/Domain/Integrations/Composer/PhpFrameworks.swift
@@ -29,7 +29,7 @@ struct PhpFrameworks {
         
         "craftcms/craft": "Craft",
         "drupal/core": "Drupal",
-        "flarum/flarum": "Flarum",
+        "flarum/core": "Flarum",
         "tightenco/jigsaw": "Jigsaw",
         "joomla/uri": "Joomla",
         "themsaid/katana": "Katana",


### PR DESCRIPTION
Not 100% sure if this is fitting, since its not so much a "framework" - but I saw Wordpress on the list so I thought it might be alright 😄

In case you haven't heard of Flarum, it is a very popular forum software which is built off of many Illuminate components: https://github.com/flarum/flarum