### PR TITLE
Adjust composer symlink path suggestion

### DIFF
--- a/phpmon/Localizable.strings
+++ b/phpmon/Localizable.strings
@@ -180,7 +180,7 @@
 
 // Composer Update
 "alert.composer_missing.title" = "Composer not found!";
-"alert.composer_missing.info" = "Make sure you have Composer available in `/usr/local/bin/composer`. If Composer is located somewhere else, please create a symlink, like so (make sure to use the correct path):\n\n`ln -s /path/to/composer /user/local/bin`.";
+"alert.composer_missing.info" = "Make sure you have Composer available in `/usr/local/bin/composer`. If Composer is located somewhere else, please create a symlink, like so (make sure to use the correct path):\n\n`ln -s /path/to/composer /usr/local/bin`.";
 
 "alert.composer_progress.title" = "Updating global dependencies...";
 "alert.composer_progress.info" = "You can see the progress in the terminal output below.";


### PR DESCRIPTION
This PR fixes the Composer symlink suggestion.

I know the PR disclaimer said not to to open PRs for small things, but I figured this is an easy way to point out the typo. Feel free to close it!

Love the new 5.0 release.